### PR TITLE
Support baseUrl configuration for custom redirect_uri

### DIFF
--- a/auth0_client.js
+++ b/auth0_client.js
@@ -22,7 +22,18 @@ Auth0.requestCredential = function (options, credentialRequestCompleteCallback) 
   options = options || {};
   options.response_type = options.response_type || 'code';
   options.client_id = config.clientId;
-  options.redirect_uri = Meteor.absoluteUrl('_oauth/auth0?close');
+
+  options.redirect_uri = (function(baseUrl) {
+    var suffix = '_oauth/auth0?close';
+
+    if (baseUrl) {
+      var separator = baseUrl.slice(-1) === '/' ? '' : '/';
+      return baseUrl + separator + suffix;
+    } else {
+      return Meteor.absoluteUrl(suffix);
+    }
+  })(config.baseUrl);
+
   options.state = Random.id();
 
   var loginUrl = 'https://' + config.domain + '/authorize?';
@@ -32,10 +43,11 @@ Auth0.requestCredential = function (options, credentialRequestCompleteCallback) 
   }
 
   options.popupOptions = options.popupOptions || {};
-  var popupOptions = { 
-    width:  options.popupOptions.width || 320, 
+  var popupOptions = {
+    width:  options.popupOptions.width || 320,
     height: options.popupOptions.height || 450
   };
 
   Oauth.initiateLogin(options.state, loginUrl, credentialRequestCompleteCallback, popupOptions);
 };
+

--- a/auth0_server.js
+++ b/auth0_server.js
@@ -49,7 +49,7 @@ var getTokens = function (query) {
           client_secret:  config.clientSecret,
           grant_type:     'authorization_code',
           redirect_uri:   (function(baseUrl) {
-            var suffix = '_oauth/auth0?close';
+            var suffix = '_oauth/auth0';
 
             if (baseUrl) {
               var separator = baseUrl.slice(-1) === '/' ? '' : '/';

--- a/auth0_server.js
+++ b/auth0_server.js
@@ -33,6 +33,7 @@ if (Meteor.release) {
 var getTokens = function (query) {
   var config = getConfiguration();
   var response;
+
   try {
 
     response = HTTP.post(
@@ -47,7 +48,16 @@ var getTokens = function (query) {
           client_id:      config.clientId,
           client_secret:  config.clientSecret,
           grant_type:     'authorization_code',
-          redirect_uri:   Meteor.absoluteUrl('_oauth/auth0')
+          redirect_uri:   (function(baseUrl) {
+            var suffix = '_oauth/auth0?close';
+
+            if (baseUrl) {
+              var separator = baseUrl.slice(-1) === '/' ? '' : '/';
+              return baseUrl + separator + suffix;
+            } else {
+              return Meteor.absoluteUrl(suffix);
+            }
+          })(config.baseUrl)
         }
       });
   }


### PR DESCRIPTION
This provides the flexibility to set a custom redirect_uri with Meteor's absoluteUrl method as a fallback.
Example:

~~~js
ServiceConfiguration.configurations.remove({ service: 'auth0' });
ServiceConfiguration.configurations.insert({
  service:      'auth0',
  domain:       '{YOUR_AUTH0_DOMAIN}',
  clientId:     '{YOUR_AUTH0_CLIENT_ID}',
  clientSecret: '{YOUR_AUTH0_CLIENT_SECRET}',
  baseUrl:      'domain.com'
});
~~~